### PR TITLE
more precise typing for the type field

### DIFF
--- a/src/bodies/box.ts
+++ b/src/bodies/box.ts
@@ -17,7 +17,7 @@ export class Box extends SAT.Polygon implements BBox, ICollider {
   isTrigger?: boolean;
   system?: System;
 
-  readonly type: Types.Box = Types.Box;
+  readonly type: Types.Box | Types.Point = Types.Box;
 
   /**
    * collider - box

--- a/src/bodies/box.ts
+++ b/src/bodies/box.ts
@@ -17,7 +17,7 @@ export class Box extends SAT.Polygon implements BBox, ICollider {
   isTrigger?: boolean;
   system?: System;
 
-  readonly type: Types = Types.Box;
+  readonly type: Types.Box = Types.Box;
 
   /**
    * collider - box

--- a/src/bodies/circle.ts
+++ b/src/bodies/circle.ts
@@ -16,7 +16,7 @@ export class Circle extends SAT.Circle implements BBox, ICollider {
   isTrigger?: boolean;
   system?: System;
 
-  readonly type: Types = Types.Circle;
+  readonly type: Types.Circle = Types.Circle;
 
   /**
    * collider - circle

--- a/src/bodies/point.ts
+++ b/src/bodies/point.ts
@@ -6,7 +6,7 @@ import { ensureVectorPoint } from "../utils";
  * collider - point (very tiny box)
  */
 export class Point extends Box {
-  readonly type: Types = Types.Point;
+  readonly type: Types.Point = Types.Point;
 
   /**
    * collider - point (very tiny box)

--- a/src/bodies/polygon.ts
+++ b/src/bodies/polygon.ts
@@ -16,7 +16,7 @@ export class Polygon extends SAT.Polygon implements BBox, ICollider {
   isTrigger?: boolean;
   system?: System;
 
-  readonly type: Types = Types.Polygon;
+  readonly type: Types.Polygon = Types.Polygon;
 
   /**
    * collider - polygon

--- a/src/model.ts
+++ b/src/model.ts
@@ -28,7 +28,7 @@ export interface ICollider {
   /**
    * type of collider
    */
-  type: Types;
+  readonly type: Types;
 
   /**
    * is the collider non moving


### PR DESCRIPTION
I've narrowed the type of the `type` field in the bodies. 
This way it's very easy to get typescript type guards working with a union of body types:
```typescript
            if (body.type === 'Circle') { // body is of type TBody
                body.r = radius;  // inside the if statement, body is of type Circle, thank you Typescript!
            }
```