### PR TITLE
Optimize usage of Array.map, Array.forEach, and Array.filter

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/src/base-system.ts
+++ b/src/base-system.ts
@@ -14,6 +14,7 @@ import {
   RBush,
   Vector,
 } from "./model";
+import { forEach } from "./optimized";
 import { createBox, drawPolygon } from "./utils";
 
 /**
@@ -26,7 +27,7 @@ export class BaseSystem extends RBush<Body> implements Data {
    * draw bodies
    */
   draw(context: CanvasRenderingContext2D): void {
-    this.all().forEach((body: Body) => {
+    forEach(this.all(), (body: Body) => {
       body.draw(context);
     });
   }
@@ -41,10 +42,10 @@ export class BaseSystem extends RBush<Body> implements Data {
         calcPoints: createBox(maxX - x, maxY - y),
       });
 
-      children?.forEach(drawChildren);
+      forEach(children, drawChildren);
     };
 
-    this.data.children.forEach(drawChildren);
+    forEach(this.data.children, drawChildren);
   }
 
   /**

--- a/src/bodies/polygon.ts
+++ b/src/bodies/polygon.ts
@@ -12,6 +12,7 @@ import {
   BodyType,
   Vector,
 } from "../model";
+import { forEach, map } from "../optimized";
 import { System } from "../system";
 import {
   ensurePolygonPoints,
@@ -221,7 +222,7 @@ export class Polygon extends SATPolygon implements BBox, BodyProps {
     this.scaleVector.x = x;
     this.scaleVector.y = y;
 
-    this.points.forEach((point: SATVector, i: number) => {
+    forEach(this.points, (point: SATVector, i: number) => {
       point.x = this.pointsBackup[i].x * x;
       point.y = this.pointsBackup[i].y * y;
     });
@@ -302,7 +303,7 @@ export class Polygon extends SATPolygon implements BBox, BodyProps {
    * after the position of the body has changed
    */
   protected updateConvexPolygonPositions() {
-    this.convexPolygons?.forEach((polygon: SATPolygon) => {
+    forEach(this.convexPolygons, (polygon: SATPolygon) => {
       polygon.pos.x = this.pos.x;
       polygon.pos.y = this.pos.y;
     });
@@ -319,7 +320,7 @@ export class Polygon extends SATPolygon implements BBox, BodyProps {
       return [];
     }
 
-    const points = this.calcPoints.map(mapVectorToArray);
+    const points = map(this.calcPoints, mapVectorToArray);
 
     if (isSimple(points)) {
       return quickDecomp(points);
@@ -342,7 +343,7 @@ export class Polygon extends SATPolygon implements BBox, BodyProps {
       this.convexPolygons = [];
     }
 
-    convex.forEach((points: DecompPolygon, index: number) => {
+    forEach(convex, (points: DecompPolygon, index: number) => {
       // lazy create
       if (!this.convexPolygons[index]) {
         this.convexPolygons[index] = new SATPolygon();
@@ -351,7 +352,7 @@ export class Polygon extends SATPolygon implements BBox, BodyProps {
       this.convexPolygons[index].pos.x = this.pos.x;
       this.convexPolygons[index].pos.y = this.pos.y;
       this.convexPolygons[index].setPoints(
-        ensurePolygonPoints(points.map(mapArrayToVector))
+        ensurePolygonPoints(map(points, mapArrayToVector))
       );
     });
 

--- a/src/intersect.ts
+++ b/src/intersect.ts
@@ -5,6 +5,7 @@ import { Circle } from "./bodies/circle";
 import { Polygon } from "./bodies/polygon";
 import { Line } from "./bodies/line";
 import { ensureConvex } from "./utils";
+import { filter, map } from "./optimized";
 
 export function polygonInCircle(
   { pos, calcPoints }: Polygon,
@@ -70,7 +71,7 @@ export function circleInPolygon(
   }
 
   // Necessary add polygon pos to points
-  const points = polygon.calcPoints.map(({ x, y }) => ({
+  const points = map(polygon.calcPoints, ({ x, y }: SATVector) => ({
     x: x + polygon.pos.x,
     y: y + polygon.pos.y,
   })) as SATVector[];
@@ -127,7 +128,7 @@ export function circleOutsidePolygon(
   }
 
   // Necessary add polygon pos to points
-  const points = polygon.calcPoints.map(({ x, y }) => ({
+  const points = map(polygon.calcPoints, ({ x, y }: SATVector) => ({
     x: x + polygon.pos.x,
     y: y + polygon.pos.y,
   })) as SATVector[];
@@ -232,8 +233,8 @@ export function intersectLineLine(
 }
 
 export function intersectLinePolygon(line: Line, polygon: Polygon): Vector[] {
-  return polygon.calcPoints
-    .map((to: Vector, index: number) => {
+  return filter(
+    map(polygon.calcPoints, (to: Vector, index: number) => {
       const from: Vector = index
         ? polygon.calcPoints[index - 1]
         : polygon.calcPoints[polygon.calcPoints.length - 1];
@@ -243,6 +244,7 @@ export function intersectLinePolygon(line: Line, polygon: Polygon): Vector[] {
       };
 
       return intersectLineLine(line, side);
-    })
-    .filter((test: Vector | null) => !!test) as Vector[];
+    }),
+    (test: Vector | null) => !!test
+  ) as Vector[];
 }

--- a/src/optimized.ts
+++ b/src/optimized.ts
@@ -1,0 +1,51 @@
+/**
+ * 40-90% faster than built-in Array.forEach function.
+ *
+ * basic benchmark: https://jsbench.me/urle772xdn
+ */
+export const forEach = (array: any[] | undefined, fn: Function) => {
+  if (!array) return;
+
+  for (let i = 0, l = array.length; i < l; i++) {
+    fn(array[i], i);
+  }
+};
+
+/**
+ * 20-60% faster than built-in Array.filter function.
+ *
+ * basic benchmark: https://jsbench.me/o1le77ev4l
+ */
+export const filter = (array: any[] | undefined, fn: Function): any[] => {
+  if (!array) return [];
+
+  const output = [];
+
+  for (let i = 0, l = array.length; i < l; i++) {
+    const item = array[i];
+
+    if (fn(item, i)) {
+      output.push(item);
+    }
+  }
+
+  return output;
+};
+
+/**
+ * 20-70% faster than built-in Array.map
+ *
+ * basic benchmark: https://jsbench.me/oyle77vbpc
+ */
+export const map = (array: any[] | undefined, fn: Function): any[] => {
+  if (!array) return [];
+
+  const length = array.length;
+  const output = new Array(length);
+
+  for (let i = 0; i < length; i++) {
+    output[i] = fn(array[i], i);
+  }
+
+  return output;
+};

--- a/src/system.ts
+++ b/src/system.ts
@@ -21,6 +21,7 @@ import {
   getSATTest,
 } from "./utils";
 import { intersectLineCircle, intersectLinePolygon } from "./intersect";
+import { filter, forEach } from "./optimized";
 
 /**
  * collision system
@@ -83,7 +84,7 @@ export class System extends BaseSystem {
    * update all bodies aabb
    */
   update(): void {
-    this.all().forEach((body: Body) => {
+    forEach(this.all(), (body: Body) => {
       // no need to every cycle update static body aabb
       if (!body.isStatic) {
         this.insert(body);
@@ -146,7 +147,7 @@ export class System extends BaseSystem {
    */
   getPotentials(body: Body): Body[] {
     // filter here is required as collides with self
-    return this.search(body).filter((candidate) => candidate !== body);
+    return filter(this.search(body), (candidate: Body) => candidate !== body);
   }
 
   /**
@@ -230,7 +231,7 @@ export class System extends BaseSystem {
           ? intersectLineCircle(this.ray, body)
           : intersectLinePolygon(this.ray, body);
 
-      points.forEach((point: Vector) => {
+      forEach(points, (point: Vector) => {
         const pointDistance: number = distance(start, point);
 
         if (pointDistance < minDistance) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,6 +26,7 @@ import {
   BodyType,
   Vector,
 } from "./model";
+import { forEach, map } from "./optimized";
 
 export const DEG2RAD = Math.PI / 180;
 export const RAD2DEG = 180 / Math.PI;
@@ -93,7 +94,7 @@ export function ensurePolygonPoints(points: PotentialVector[]): SATVector[] {
     throw new Error("No points array provided");
   }
 
-  const polygonPoints: SATVector[] = points.map(ensureVectorPoint);
+  const polygonPoints: SATVector[] = map(points, ensureVectorPoint);
 
   return clockwise(polygonPoints) ? polygonPoints.reverse() : polygonPoints;
 }
@@ -181,7 +182,7 @@ export function checkAInB(a: Body, b: Body): boolean {
  * clone sat vector points array into vector points array
  */
 export function clonePointsArray(points: SATVector[]): Vector[] {
-  return points.map(({ x, y }) => ({
+  return map(points, ({ x, y }: Vector) => ({
     x,
     y,
   }));
@@ -286,7 +287,7 @@ export function drawPolygon(
 ): void {
   const loopPoints = [...calcPoints, calcPoints[0]];
 
-  loopPoints.forEach((point: Vector, index: number) => {
+  forEach(loopPoints, (point: Vector, index: number) => {
     const toX = pos.x + point.x;
     const toY = pos.y + point.y;
     const prev = calcPoints[index - 1] || calcPoints[calcPoints.length - 1];


### PR DESCRIPTION
This switches out `array.<map|forEach|filter>(cb)` for a function call `<map|forEach|filter>(array, cb)`. This is simply because the built-in array iteration functions in JS are slower than what can be done with a for-loop. The performance benefit of this is miniscule on the scale that `detect-collisions` is using these functions, but every bit helps.

Here are some basic benchmarks I made:
https://jsbench.me/urle772xdn
https://jsbench.me/o1le77ev4l
https://jsbench.me/oyle77vbpc

I ran `yarn benchmark` and there wasn't a significant difference (~2-6 FPS). This is because even the built-in functions are fast. But as I said, every little bit could help.

The main reason why I did this was because I saw the folder on my desktop and remembered the `aInB` issue. I thought I could implement a working concave `aInB`, but low-and-behold you did so yesterday. Since I had already opened the folder, I thought I might as well do something c: