### PR TITLE
check collisions within the area

### DIFF
--- a/src/system.spec.js
+++ b/src/system.spec.js
@@ -71,6 +71,31 @@ describe("GIVEN System", () => {
     expect(poly.dirty).toBe(false);
   });
 
+  it("THEN checkArea() works", () => {
+    const { System } = require("../src");
+
+    const physics = new System();
+
+    const a = physics.createBox({ x: 10, y: 10 }, 100, 100);
+    const b = physics.createBox({ x: 300, y: 300 }, 100, 100);
+
+    let collisions = 0;
+
+    physics.checkArea({ minX: 0, minY: 0, maxX: 100, maxY: 100 }, () => {
+      collisions++;
+    });
+
+    expect(collisions).toBe(0);
+
+    b.setPosition(50, 50);
+
+    physics.checkArea({ minX: 0, minY: 0, maxX: 100, maxY: 100 }, () => {
+      collisions++;
+    });
+
+    expect(collisions).toBe(2);
+  });
+
   describe("WHEN raycast is called", () => {
     it("THEN works correctly on Ellipse", () => {
       const { System } = require(".");

--- a/src/system.ts
+++ b/src/system.ts
@@ -6,6 +6,7 @@ import {
   intersectLinePolygon,
 } from "./intersect";
 import {
+  BBox,
   Body,
   BodyType,
   CollisionCallback,
@@ -91,6 +92,22 @@ export class System<TBody extends Body = Body> extends BaseSystem<TBody> {
     };
 
     return some(bodies, checkCollision);
+  }
+
+  /**
+   * check all bodies in area collisions with callback
+   */
+  checkArea(
+    area: BBox,
+    callback: CollisionCallback = returnTrue,
+    response = this.response,
+  ): boolean {
+    const bodies = this.search(area);
+    const checkOne = (body: TBody) => {
+      return this.checkOne(body, callback, response);
+    };
+
+    return some(bodies, checkOne);
   }
 
   /**


### PR DESCRIPTION
In a very large or infinite world, using `checkArea()` to limit the detection range is very useful.
