### PR TITLE
fix: should not be assumed to always interact with the same group

### DIFF
--- a/src/demo/stress.js
+++ b/src/demo/stress.js
@@ -187,7 +187,7 @@ class Stress {
     switch (variant) {
       case 0:
         if (this.enableFiltering) {
-          options.group = BodyGroup.Circle;
+          options.group = (BodyGroup.Circle << 16) | BodyGroup.Circle;
         }
         body = this.physics.createCircle(
           { x, y },
@@ -202,7 +202,7 @@ class Stress {
         const width = random(minSize, maxSize);
         const height = random(minSize, maxSize);
         if (this.enableFiltering) {
-          options.group = BodyGroup.Ellipse;
+          options.group = (BodyGroup.Ellipse << 16) | BodyGroup.Ellipse;
           console.log();
         }
         body = this.physics.createEllipse({ x, y }, width, height, 2, options);
@@ -212,7 +212,7 @@ class Stress {
 
       case 2:
         if (this.enableFiltering) {
-          options.group = BodyGroup.Box;
+          options.group = (BodyGroup.Box << 16) | BodyGroup.Box;
         }
         body = this.physics.createBox(
           { x, y },
@@ -226,7 +226,7 @@ class Stress {
 
       case 3:
         if (this.enableFiltering) {
-          options.group = BodyGroup.Line;
+          options.group = (BodyGroup.Line << 16) | BodyGroup.Line;
         }
         body = this.physics.createLine(
           { x, y },
@@ -242,7 +242,7 @@ class Stress {
 
       default:
         if (this.enableFiltering) {
-          options.group = BodyGroup.Polygon;
+          options.group = (BodyGroup.Polygon << 16) | BodyGroup.Polygon;
         }
         body = this.physics.createPolygon(
           { x, y },

--- a/src/demo/stress.js
+++ b/src/demo/stress.js
@@ -1,6 +1,6 @@
 const { BodyGroup } = require("../model");
 const { System } = require("../system");
-const { getBounceDirection } = require("../utils");
+const { getBounceDirection, groupBits } = require("../utils");
 const { width, height, loop } = require("./canvas");
 const seededRandom = require("random-seed").create("@Prozi").random;
 
@@ -187,7 +187,7 @@ class Stress {
     switch (variant) {
       case 0:
         if (this.enableFiltering) {
-          options.group = (BodyGroup.Circle << 16) | BodyGroup.Circle;
+          options.group = groupBits(BodyGroup.Circle);
         }
         body = this.physics.createCircle(
           { x, y },
@@ -202,7 +202,7 @@ class Stress {
         const width = random(minSize, maxSize);
         const height = random(minSize, maxSize);
         if (this.enableFiltering) {
-          options.group = (BodyGroup.Ellipse << 16) | BodyGroup.Ellipse;
+          options.group = groupBits(BodyGroup.Ellipse);
           console.log();
         }
         body = this.physics.createEllipse({ x, y }, width, height, 2, options);
@@ -212,7 +212,7 @@ class Stress {
 
       case 2:
         if (this.enableFiltering) {
-          options.group = (BodyGroup.Box << 16) | BodyGroup.Box;
+          options.group = groupBits(BodyGroup.Box);
         }
         body = this.physics.createBox(
           { x, y },
@@ -226,7 +226,7 @@ class Stress {
 
       case 3:
         if (this.enableFiltering) {
-          options.group = (BodyGroup.Line << 16) | BodyGroup.Line;
+          options.group = groupBits(BodyGroup.Line);
         }
         body = this.physics.createLine(
           { x, y },
@@ -242,7 +242,7 @@ class Stress {
 
       default:
         if (this.enableFiltering) {
-          options.group = (BodyGroup.Polygon << 16) | BodyGroup.Polygon;
+          options.group = groupBits(BodyGroup.Polygon);
         }
         body = this.physics.createPolygon(
           { x, y },

--- a/src/model.ts
+++ b/src/model.ts
@@ -40,9 +40,7 @@ export enum BodyType {
  * for groups
  */
 export function getGroup(group: number): number {
-  const limited = Math.max(0, Math.min(group, 0x7fffffff));
-
-  return (limited << 16) | limited;
+  return Math.max(0, Math.min(group, 0x7fffffff));
 }
 
 /**

--- a/src/system.ts
+++ b/src/system.ts
@@ -19,7 +19,7 @@ import {
 } from "./model";
 import { forEach, some } from "./optimized";
 import {
-  areSameGroup,
+  canInteract,
   checkAInB,
   distance,
   getSATTest,
@@ -150,7 +150,7 @@ export class System<TBody extends Body = Body> extends BaseSystem<TBody> {
     const { bbox: bboxB } = bodyA;
     // assess the bodies real aabb without padding
     if (
-      !areSameGroup(bodyA, bodyB) ||
+      !canInteract(bodyA, bodyB) ||
       !bboxA ||
       !bboxB ||
       notIntersectAABB(bboxA, bboxB)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -382,3 +382,18 @@ export function returnTrue() {
 export function bin2dec(binary: string): number {
   return Number(`0b${binary}`.replace(/\s/g, ""));
 }
+
+/**
+ * create group bits from category and mask
+ *
+ * @param category - category bits
+ * @param mask - mask bits (default: category)
+ */
+export function groupBits(
+  category: string | number,
+  mask: string | number = category,
+) {
+  const c = typeof category === "string" ? bin2dec(category) : category;
+  const m = typeof mask === "string" ? bin2dec(mask) : mask;
+  return (c << 16) | m;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -211,7 +211,7 @@ export function intersectAABB(bodyA: BBox, bodyB: BBox): boolean {
 /**
  * checks if two bodies can interact (for collision filtering)
  */
-export function areSameGroup(bodyA: Body, bodyB: Body): boolean {
+export function canInteract(bodyA: Body, bodyB: Body): boolean {
   return (
     ((bodyA.group >> 16) & (bodyB.group & 0xffff) &&
       (bodyB.group >> 16) & (bodyA.group & 0xffff)) !== 0


### PR DESCRIPTION
The interactive group is set by the users and should not be assumed to always interact with the same group. For example, a circle can also collide with a rectangle, but they still belong to different groups. 

Stress testing is set to the same group only for testing purposes. 

Here are two links for reference:
[Box2d Doc](https://box2d.org/documentation_v3/md_dynamics.html#autotoc_md80)
[Box2D Tutorial: Collision filtering](https://aurelienribon.wordpress.com/2011/07/01/box2d-tutorial-collision-filtering/)