### PR TITLE
fix: bbox check uses bodyA twice

### DIFF
--- a/src/system.spec.js
+++ b/src/system.spec.js
@@ -96,6 +96,23 @@ describe("GIVEN System", () => {
     expect(collisions).toBe(2);
   });
 
+  it("THEN bodies with non-intersecting bbox don't check collisions", () => {
+    const { System } = require("../src");
+
+    const physics = new System();
+
+    const a = physics.createBox({ x: 10, y: 10 }, 100, 100);
+    const b = physics.createBox({ x: 300, y: 300 }, 100, 100);
+
+    // Set values in response that should not be changed because of early return
+    physics.response.overlap = 0xdeadbeaf;
+
+    const didCollide = physics.checkCollision(a, b);
+
+    expect(didCollide).toBe(false);
+    expect(physics.response.overlap).toBe(0xdeadbeaf);
+  });
+
   describe("WHEN raycast is called", () => {
     it("THEN works correctly on Ellipse", () => {
       const { System } = require(".");

--- a/src/system.ts
+++ b/src/system.ts
@@ -147,7 +147,7 @@ export class System<TBody extends Body = Body> extends BaseSystem<TBody> {
     response = this.response,
   ): boolean {
     const { bbox: bboxA } = bodyA;
-    const { bbox: bboxB } = bodyA;
+    const { bbox: bboxB } = bodyB;
     // assess the bodies real aabb without padding
     if (
       !canInteract(bodyA, bodyB) ||


### PR DESCRIPTION
In `checkCollision` the bbox of bodyA was used twice. When this is fixed `checkCollision` returns early and this PR includes a test for this case