### PR TITLE
adding `userData` with a type of `any`

### DIFF
--- a/dist/bodies/circle.d.ts
+++ b/dist/bodies/circle.d.ts
@@ -66,6 +66,10 @@ export declare class Circle extends SATCircle implements BBox, BodyProps {
    * was the polygon modified and needs update in the next checkCollision
    */
   dirty: boolean;
+  /**
+   * allows the user to set any misc data for client use
+   */
+  userData: null;
   readonly isConvex = true;
   /**
    * circle type

--- a/dist/bodies/circle.js
+++ b/dist/bodies/circle.js
@@ -21,6 +21,10 @@ class Circle extends sat_1.Circle {
      * was the polygon modified and needs update in the next checkCollision
      */
     this.dirty = false;
+    /**
+     * allows the user to set any misc data for client use
+     */
+    this.userData = null;
     /*
      * circles are convex
      */

--- a/dist/bodies/polygon.d.ts
+++ b/dist/bodies/polygon.d.ts
@@ -66,6 +66,10 @@ export declare class Polygon extends SATPolygon implements BBox, BodyProps {
    */
   dirty: boolean;
   /**
+   * allows the user to set any misc data for client use
+   */
+  userData: null;
+  /**
    * type of body
    */
   readonly type:

--- a/dist/bodies/polygon.js
+++ b/dist/bodies/polygon.js
@@ -29,6 +29,10 @@ class Polygon extends sat_1.Polygon {
      */
     this.dirty = false;
     /**
+     * allows the user to set any misc data for client use
+     */
+    this.userData = null;
+    /**
      * type of body
      */
     this.type = model_1.BodyType.Polygon;

--- a/dist/demo/demo.js
+++ b/dist/demo/demo.js
@@ -2635,6 +2635,10 @@ which is good.	See: http://baagoe.com/en/RandomMusings/hash/avalanche.xhtml
              * was the polygon modified and needs update in the next checkCollision
              */
             this.dirty = false;
+            /**
+             * allows the user to set any misc data for client use
+             */
+            this.userData = null;
             /*
              * circles are convex
              */
@@ -3152,6 +3156,10 @@ which is good.	See: http://baagoe.com/en/RandomMusings/hash/avalanche.xhtml
              * was the polygon modified and needs update in the next checkCollision
              */
             this.dirty = false;
+            /**
+             * allows the user to set any misc data for client use
+             */
+            this.userData = null;
             /**
              * type of body
              */
@@ -4344,6 +4352,7 @@ which is good.	See: http://baagoe.com/en/RandomMusings/hash/avalanche.xhtml
           // Default value should be reflected in documentation of `BodyOptions.group`
           body.group =
             (_a = options.group) !== null && _a !== void 0 ? _a : 0x7fffffff;
+          body.userData = options.userData || null;
           if (
             body.typeGroup !== model_1.BodyGroup.Circle &&
             options.isCentered

--- a/dist/model.d.ts
+++ b/dist/model.d.ts
@@ -104,6 +104,10 @@ export interface BodyOptions {
    * @default 0x7fffffff // member of all groups (can interact with everyting)
    */
   group?: number;
+  /**
+   * allows the user to set any misc data for client use
+   */
+  userData?: any;
 }
 /**
  * system.raycast(from, to) result

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -147,6 +147,7 @@ function extendBody(body, options = {}) {
   body.padding = options.padding || 0;
   // Default value should be reflected in documentation of `BodyOptions.group`
   body.group = (_a = options.group) !== null && _a !== void 0 ? _a : 0x7fffffff;
+  body.userData = options.userData || null;
   if (body.typeGroup !== model_1.BodyGroup.Circle && options.isCentered) {
     body.isCentered = true;
   }

--- a/src/bodies/circle.ts
+++ b/src/bodies/circle.ts
@@ -89,6 +89,11 @@ export class Circle extends SATCircle implements BBox, BodyProps {
    */
   dirty = false;
 
+  /**
+   * allows the user to set any misc data for client use
+   */
+  userData = null;
+
   /*
    * circles are convex
    */

--- a/src/bodies/polygon.ts
+++ b/src/bodies/polygon.ts
@@ -95,6 +95,11 @@ export class Polygon extends SATPolygon implements BBox, BodyProps {
   dirty = false;
 
   /**
+   * allows the user to set any misc data for client use
+   */
+  userData = null;
+
+  /**
    * type of body
    */
   readonly type:

--- a/src/model.ts
+++ b/src/model.ts
@@ -125,6 +125,11 @@ export interface BodyOptions {
    * @default 0x7fffffff // member of all groups (can interact with everyting)
    */
   group?: number;
+
+  /**
+   * allows the user to set any misc data for client use
+   */
+  userData?: any;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -175,6 +175,7 @@ export function extendBody(body: Body, options: BodyOptions = {}): void {
   body.padding = options.padding || 0;
   // Default value should be reflected in documentation of `BodyOptions.group`
   body.group = options.group ?? 0x7fffffff;
+  body.userData = options.userData || null;
 
   if (body.typeGroup !== BodyGroup.Circle && options.isCentered) {
     body.isCentered = true;

--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,7 @@
     "ban-types": [true],
     "member-access": [true, "no-public"],
     "member-ordering": [true, { "order": "fields-first" }],
-    "no-any": true,
+    "no-any": false,
     "no-empty-interface": true,
     "no-import-side-effect": false,
     "no-inferrable-types": true,


### PR DESCRIPTION
I breaking one of the rules to allow an `any` type (if I'm doing it correctly)
This would be handy to pass in with the options when creating a body