### PR TITLE
Fix `Body#userData` intellisense

### DIFF
--- a/src/bodies/circle.ts
+++ b/src/bodies/circle.ts
@@ -103,7 +103,7 @@ export class Circle<UserDataType = any>
   /**
    * allows the user to set any misc data for client use
    */
-  userData?: BodyProps["userData"];
+  userData?: BodyProps<UserDataType>["userData"];
 
   /*
    * circles are convex

--- a/src/bodies/polygon.ts
+++ b/src/bodies/polygon.ts
@@ -105,7 +105,7 @@ export class Polygon<UserDataType = any>
   /**
    * allows the user to set any misc data for client use
    */
-  userData?: BodyProps["userData"];
+  userData?: BodyProps<UserDataType>["userData"];
 
   /**
    * type of body


### PR DESCRIPTION
When creating new bodies with an `UserData` interface, the intellisense wasn't working:

**Before:**
```ts
const system = this.system;
const body = system.createCircle({ x: 0, y: 0 }, 128, {
  userData: {
    tag: "player",
  }
}) as Circle<{ tag: "player" }>;
body.userData.tag // No intellisense! because `userData` is still any.
```
![image](https://github.com/user-attachments/assets/abcbf255-e2df-4993-b841-747fa2c675fc)


**After:**
```ts
const system = this.system;
const body = system.createCircle({ x: 0, y: 0 }, 128, {
  userData: {
    tag: "player",
  }
}) as Circle<{ tag: "player" }>;
body.userData.tag // string!
```
![image](https://github.com/user-attachments/assets/4f043ac0-fc22-4fa2-9a02-fa5a5cecc5de)


